### PR TITLE
Fix inappropriate `ReflectionHelper` usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 minecraft_version=1.12.2
-forge_version=14.23.5.2772
+forge_version=14.23.5.2811
 mapping_version=stable_39
 
 version_major=0

--- a/src/main/java/team/covertdragon/springfestival/module/firecracker/ModuleFirecracker.java
+++ b/src/main/java/team/covertdragon/springfestival/module/firecracker/ModuleFirecracker.java
@@ -41,10 +41,10 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import team.covertdragon.springfestival.SpringFestival;
@@ -66,8 +66,15 @@ public class ModuleFirecracker extends AbstractSpringFestivalModule {
     // TODO Albedo support? Are we sure on this one?
     // TODO The compatibility should be done via {@link net.minecraftforge.fml.common.Optional.Interface}
 //    public static Boolean useFancyLighting;
-    private static final Field FIELD_AVOID_CLASS = ReflectionHelper.findField(EntityAIAvoidEntity.class, "field_181064_i", "classToAvoid");
-    private static final Field FIELD_DISPENSE_RESULT = ReflectionHelper.findField(Bootstrap.BehaviorDispenseOptional.class, "field_190911_b", "successful");
+    /*
+     * We use the ObfuscationReflectionHelper because ReflectionHelper under relauncher package is in the Land of C***mod,
+     * implying that those two classes are on different class loaders. Since we are regular FML mods, we use the one
+     * that is on the same class loader as of which we are on.
+     */
+    private static final Field FIELD_AVOID_CLASS = ObfuscationReflectionHelper.findField(EntityAIAvoidEntity.class, "field_181064_i");
+    // TODO (3TUSK): I guess we can actually cast that instance of anonymous class to Bootstrap.BehaviorDispenseOptional,
+    //  so we don't need extra reflection.
+    private static final Field FIELD_DISPENSE_RESULT = ObfuscationReflectionHelper.findField(Bootstrap.BehaviorDispenseOptional.class, "field_190911_b");
 
     public void onInit() {
         EntityRegistry.registerModEntity(new ResourceLocation(SpringFestivalConstants.MOD_ID, "firecracker"), EntityFirecracker.class, "Firecracker", 0, SpringFestival.getInstance(), 80, 3, true);

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -10,6 +10,9 @@
     "authorList": ["CovertDragon Team"],
     "credits": "You",
     "logoFile": "logo.png",
-    "screenshots": []
+    "screenshots": [],
+    "useDependencyInformation": true,
+    "requiredMods": [ "forge@[14.23.5.2779,)" ],
+    "dependencies": [ "forge" ]
   }
 ]


### PR DESCRIPTION
This pull request: 
 - Bump Forge version in dev env to 14.23.5.2811
 - Switch the usage of `ReflectionHelper` in `ModuleFirecracker` to `ObfuscationReflectionHelper`.
 - Raise Forge requirement to 14.23.5.2779 so that we have the access to the new `ObfuscationReflectionHelper`.